### PR TITLE
fix: ids

### DIFF
--- a/.changeset/popular-tables-itch.md
+++ b/.changeset/popular-tables-itch.md
@@ -1,0 +1,5 @@
+---
+"@sebspark/opensearch": patch
+---
+
+Fixed support for ids query.

--- a/packages/openapi-client/src/test/openapi.ts
+++ b/packages/openapi-client/src/test/openapi.ts
@@ -64,7 +64,7 @@ export type OpenapiServer = APIServerDefinition & {
        * @returns {Promise<[200, APIResponse<PartiallySerialized<UserList>>]>}
        */
       handler: (
-        args: Req & { headers: LowerCaseHeaders<AccessToken> },
+        args: Req & { headers: LowerCaseHeaders<AccessToken> }
       ) => Promise<[200, APIResponse<PartiallySerialized<UserList>>]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -77,7 +77,7 @@ export type OpenapiServer = APIServerDefinition & {
        * @returns {Promise<[201, APIResponse<PartiallySerialized<User>>]>}
        */
       handler: (
-        args: Req & { body: User; headers: LowerCaseHeaders<AccessToken> },
+        args: Req & { body: User; headers: LowerCaseHeaders<AccessToken> }
       ) => Promise<[201, APIResponse<PartiallySerialized<User>>]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -98,7 +98,7 @@ export type OpenapiServer = APIServerDefinition & {
           params: {
             userId: string
           }
-        },
+        }
       ) => Promise<[204, undefined]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -117,7 +117,7 @@ export type OpenapiServer = APIServerDefinition & {
           params: {
             userId: string
           }
-        },
+        }
       ) => Promise<[200, APIResponse<PartiallySerialized<User>>]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -138,7 +138,7 @@ export type OpenapiServer = APIServerDefinition & {
           params: {
             userId: string
           }
-        },
+        }
       ) => Promise<[200, APIResponse<PartiallySerialized<User>>]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -167,7 +167,7 @@ export type OpenapiServer = APIServerDefinition & {
           params: {
             id: string
           }
-        },
+        }
       ) => Promise<[204, undefined]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -190,7 +190,7 @@ export type OpenapiClient = Pick<
     (
       url: '/users',
       args: { headers: AccessToken },
-      opts?: RequestOptions,
+      opts?: RequestOptions
     ): Promise<APIResponse<Serialized<UserList>>>
     /**
      *
@@ -210,7 +210,7 @@ export type OpenapiClient = Pick<
           userId: string
         }
       },
-      opts?: RequestOptions,
+      opts?: RequestOptions
     ): Promise<APIResponse<Serialized<User>>>
     /**
      *
@@ -235,7 +235,7 @@ export type OpenapiClient = Pick<
           id: string
         }
       },
-      opts?: RequestOptions,
+      opts?: RequestOptions
     ): Promise<undefined>
   }
   post: {
@@ -251,7 +251,7 @@ export type OpenapiClient = Pick<
     (
       url: '/users',
       args: { body: User; headers: AccessToken },
-      opts?: RequestOptions,
+      opts?: RequestOptions
     ): Promise<APIResponse<Serialized<User>>>
   }
   delete: {
@@ -273,7 +273,7 @@ export type OpenapiClient = Pick<
           userId: string
         }
       },
-      opts?: RequestOptions,
+      opts?: RequestOptions
     ): Promise<undefined>
   }
   put: {
@@ -297,7 +297,7 @@ export type OpenapiClient = Pick<
           userId: string
         }
       },
-      opts?: RequestOptions,
+      opts?: RequestOptions
     ): Promise<APIResponse<Serialized<User>>>
   }
 }

--- a/packages/openapi-client/src/test/openapi.ts
+++ b/packages/openapi-client/src/test/openapi.ts
@@ -64,7 +64,7 @@ export type OpenapiServer = APIServerDefinition & {
        * @returns {Promise<[200, APIResponse<PartiallySerialized<UserList>>]>}
        */
       handler: (
-        args: Req & { headers: LowerCaseHeaders<AccessToken> }
+        args: Req & { headers: LowerCaseHeaders<AccessToken> },
       ) => Promise<[200, APIResponse<PartiallySerialized<UserList>>]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -77,7 +77,7 @@ export type OpenapiServer = APIServerDefinition & {
        * @returns {Promise<[201, APIResponse<PartiallySerialized<User>>]>}
        */
       handler: (
-        args: Req & { body: User; headers: LowerCaseHeaders<AccessToken> }
+        args: Req & { body: User; headers: LowerCaseHeaders<AccessToken> },
       ) => Promise<[201, APIResponse<PartiallySerialized<User>>]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -98,7 +98,7 @@ export type OpenapiServer = APIServerDefinition & {
           params: {
             userId: string
           }
-        }
+        },
       ) => Promise<[204, undefined]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -117,7 +117,7 @@ export type OpenapiServer = APIServerDefinition & {
           params: {
             userId: string
           }
-        }
+        },
       ) => Promise<[200, APIResponse<PartiallySerialized<User>>]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -138,7 +138,7 @@ export type OpenapiServer = APIServerDefinition & {
           params: {
             userId: string
           }
-        }
+        },
       ) => Promise<[200, APIResponse<PartiallySerialized<User>>]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -167,7 +167,7 @@ export type OpenapiServer = APIServerDefinition & {
           params: {
             id: string
           }
-        }
+        },
       ) => Promise<[204, undefined]>
       pre?: GenericRouteHandler | GenericRouteHandler[]
     }
@@ -190,7 +190,7 @@ export type OpenapiClient = Pick<
     (
       url: '/users',
       args: { headers: AccessToken },
-      opts?: RequestOptions
+      opts?: RequestOptions,
     ): Promise<APIResponse<Serialized<UserList>>>
     /**
      *
@@ -210,7 +210,7 @@ export type OpenapiClient = Pick<
           userId: string
         }
       },
-      opts?: RequestOptions
+      opts?: RequestOptions,
     ): Promise<APIResponse<Serialized<User>>>
     /**
      *
@@ -235,7 +235,7 @@ export type OpenapiClient = Pick<
           id: string
         }
       },
-      opts?: RequestOptions
+      opts?: RequestOptions,
     ): Promise<undefined>
   }
   post: {
@@ -251,7 +251,7 @@ export type OpenapiClient = Pick<
     (
       url: '/users',
       args: { body: User; headers: AccessToken },
-      opts?: RequestOptions
+      opts?: RequestOptions,
     ): Promise<APIResponse<Serialized<User>>>
   }
   delete: {
@@ -273,7 +273,7 @@ export type OpenapiClient = Pick<
           userId: string
         }
       },
-      opts?: RequestOptions
+      opts?: RequestOptions,
     ): Promise<undefined>
   }
   put: {
@@ -297,7 +297,7 @@ export type OpenapiClient = Pick<
           userId: string
         }
       },
-      opts?: RequestOptions
+      opts?: RequestOptions,
     ): Promise<APIResponse<Serialized<User>>>
   }
 }

--- a/packages/opensearch/src/fixIds.ts
+++ b/packages/opensearch/src/fixIds.ts
@@ -17,6 +17,7 @@ export const fixIds = <T extends WithId, K = T>(
   const { query: q, _source, from, size, sort } = searchQuery.body
   const body: NativeOpenSearchQueryBody<NativeOpenSearchType<T>, K> = {
     query: {
+      ids: q.ids,
       bool: q.bool ? fixBool(q.bool) : undefined,
       match: q.match ? fixId(q.match) : undefined,
       collapse: q.collapse,

--- a/packages/opensearch/src/openSearchHelper.spec.ts
+++ b/packages/opensearch/src/openSearchHelper.spec.ts
@@ -336,7 +336,9 @@ describe('OpenSearchHelper', () => {
         index: 'data',
         body: {
           query: {
-            ids: ids,
+            ids: {
+              values: ids,
+            },
           },
         },
       })
@@ -344,7 +346,9 @@ describe('OpenSearchHelper', () => {
         index: 'data',
         body: {
           query: {
-            ids: ['foo', 'bar', 'baz'],
+            ids: {
+              values: ['foo', 'bar', 'baz'],
+            },
           },
         },
       })

--- a/packages/opensearch/src/openSearchHelper.spec.ts
+++ b/packages/opensearch/src/openSearchHelper.spec.ts
@@ -330,6 +330,25 @@ describe('OpenSearchHelper', () => {
         },
       })
     })
+    it('handles ids', async () => {
+      const ids = ['foo', 'bar', 'baz']
+      await helper(client as Client).typedSearch<Data>({
+        index: 'data',
+        body: {
+          query: {
+            ids: ids,
+          },
+        },
+      })
+      expect(client.search).toHaveBeenCalledWith({
+        index: 'data',
+        body: {
+          query: {
+            ids: ['foo', 'bar', 'baz'],
+          },
+        },
+      })
+    })
     it('handles match_all', async () => {
       await helper(client as Client).typedSearch<Data>({
         index: 'data',

--- a/packages/opensearch/src/openSearchTypes.ts
+++ b/packages/opensearch/src/openSearchTypes.ts
@@ -246,6 +246,9 @@ export type OpenSearchQueryBody<
 > = K extends DeepPartial<T>
   ? {
       query: {
+        ids?: {
+          values: string[]
+        }
         // Criteria to filter the results
         filter?: OpenSearchFilter<T>
 
@@ -432,6 +435,8 @@ export type NativeOpenSearchType<T extends WithId> = ExcludeId<T> & {
 
 export type NativeOpenSearchQueryBody<T extends { _id: string }, K = T> = {
   query: {
+    ids?: { values: string[] }
+
     // Criteria to filter the results
     filter?: OpenSearchFilter<T>
 


### PR DESCRIPTION
It should be possible to request multiple documents by passing in an array of ids.

Example:
```
GET shakespeare/_search
{
  "query": {
    "ids": {
      "values": [
        34229,
        91296
      ]
    }
  }
}
```

Source: https://opensearch.org/docs/latest/query-dsl/term/ids/