### PR TITLE
fix(typegen): parse date strings

### DIFF
--- a/.changeset/kind-plants-love.md
+++ b/.changeset/kind-plants-love.md
@@ -1,0 +1,5 @@
+---
+"@sebspark/openapi-typegen": patch
+---
+
+Parse date strings as strings instead of JS Date objects

--- a/packages/openapi-typegen/src/__tests__/parser.spec.ts
+++ b/packages/openapi-typegen/src/__tests__/parser.spec.ts
@@ -874,7 +874,7 @@ describe('openapi parser', () => {
         type: 'object',
         name: 'ContainsDate',
         properties: [
-          { name: 'lastValidDate', optional: true, type: [{ type: 'Date' }] },
+          { name: 'lastValidDate', optional: true, type: [{ type: 'string' }] },
         ],
       }
       expect(parsed).toEqual(expected)

--- a/packages/openapi-typegen/src/parser/schema.ts
+++ b/packages/openapi-typegen/src/parser/schema.ts
@@ -140,15 +140,7 @@ const parsePropertyType = (
           return { type: 'number', ...parseDocumentation(schemaObject) }
         }
         case 'string': {
-          switch (schemaObject.format) {
-            case 'date':
-            case 'date-time': {
-              return { type: 'Date', ...parseDocumentation(schemaObject) }
-            }
-            default: {
-              return { type, ...parseDocumentation(schemaObject) }
-            }
-          }
+          return { type, ...parseDocumentation(schemaObject) }
         }
         default: {
           return { type, ...parseDocumentation(schemaObject) }


### PR DESCRIPTION
Generate `string` types for dates instead of `Date` when running the type generator.