### PR TITLE
Logging/refactor/make format configurable

### DIFF
--- a/packages/logging/src/lib/logger.spec.ts
+++ b/packages/logging/src/lib/logger.spec.ts
@@ -63,6 +63,40 @@ describe('logging', () => {
     })
   })
 
+  describe("formatting", () => {
+    it("has a default format", () => {
+      const spy = vi.spyOn(Winston.format, "combine");
+
+      getLogger({ service: "test", showLogs: true });
+
+      const callArgs = spy.mock.calls[0];
+      expect(callArgs).toHaveLength(5);
+      expect(callArgs[0]).toStrictEqual(Winston.format.colorize({ all: true }));
+      expect(callArgs[1]).toStrictEqual(Winston.format.timestamp());
+      expect(callArgs[2]).toStrictEqual(Winston.format.align());
+      expect(callArgs[4]).toStrictEqual(Winston.format.errors({ stack: true }));
+
+      spy.mockRestore();
+    });
+    it('options can be toggled', () => {
+      const spy = vi.spyOn(Winston.format, 'combine');
+
+      getLogger({ service: 'test', showLogs: true, formattingOptions: {
+        colorize: false,
+        align: false,
+      }});
+
+      const callArgs = spy.mock.calls[0];
+      expect(callArgs).toHaveLength(5);
+      expect(callArgs[0]).toStrictEqual(Winston.format.uncolorize());
+      expect(callArgs[1]).toStrictEqual(Winston.format.timestamp());
+      expect(callArgs[2]).toStrictEqual(Winston.format.simple());
+      expect(callArgs[4]).toStrictEqual(Winston.format.errors({ stack: true }));
+
+      spy.mockRestore();
+    });
+  });
+
   describe('express middlewares', () => {
     let server: Agent
     beforeEach(() => {

--- a/packages/logging/src/lib/logger.spec.ts
+++ b/packages/logging/src/lib/logger.spec.ts
@@ -63,39 +63,43 @@ describe('logging', () => {
     })
   })
 
-  describe("formatting", () => {
-    it("has a default format", () => {
-      const spy = vi.spyOn(Winston.format, "combine");
+  describe('formatting', () => {
+    it('has a default format', () => {
+      const spy = vi.spyOn(Winston.format, 'combine')
 
-      getLogger({ service: "test", showLogs: true });
+      getLogger({ service: 'test', showLogs: true })
 
-      const callArgs = spy.mock.calls[0];
-      expect(callArgs).toHaveLength(5);
-      expect(callArgs[0]).toStrictEqual(Winston.format.colorize({ all: true }));
-      expect(callArgs[1]).toStrictEqual(Winston.format.timestamp());
-      expect(callArgs[2]).toStrictEqual(Winston.format.align());
-      expect(callArgs[4]).toStrictEqual(Winston.format.errors({ stack: true }));
+      const callArgs = spy.mock.calls[0]
+      expect(callArgs).toHaveLength(5)
+      expect(callArgs[0]).toStrictEqual(Winston.format.colorize({ all: true }))
+      expect(callArgs[1]).toStrictEqual(Winston.format.timestamp())
+      expect(callArgs[2]).toStrictEqual(Winston.format.align())
+      expect(callArgs[4]).toStrictEqual(Winston.format.errors({ stack: true }))
 
-      spy.mockRestore();
-    });
+      spy.mockRestore()
+    })
     it('options can be toggled', () => {
-      const spy = vi.spyOn(Winston.format, 'combine');
+      const spy = vi.spyOn(Winston.format, 'combine')
 
-      getLogger({ service: 'test', showLogs: true, formattingOptions: {
-        colorize: false,
-        align: false,
-      }});
+      getLogger({
+        service: 'test',
+        showLogs: true,
+        formattingOptions: {
+          colorize: false,
+          align: false,
+        },
+      })
 
-      const callArgs = spy.mock.calls[0];
-      expect(callArgs).toHaveLength(5);
-      expect(callArgs[0]).toStrictEqual(Winston.format.uncolorize());
-      expect(callArgs[1]).toStrictEqual(Winston.format.timestamp());
-      expect(callArgs[2]).toStrictEqual(Winston.format.simple());
-      expect(callArgs[4]).toStrictEqual(Winston.format.errors({ stack: true }));
+      const callArgs = spy.mock.calls[0]
+      expect(callArgs).toHaveLength(5)
+      expect(callArgs[0]).toStrictEqual(Winston.format.uncolorize())
+      expect(callArgs[1]).toStrictEqual(Winston.format.timestamp())
+      expect(callArgs[2]).toStrictEqual(Winston.format.simple())
+      expect(callArgs[4]).toStrictEqual(Winston.format.errors({ stack: true }))
 
-      spy.mockRestore();
-    });
-  });
+      spy.mockRestore()
+    })
+  })
 
   describe('express middlewares', () => {
     let server: Agent

--- a/packages/logging/src/lib/logger.ts
+++ b/packages/logging/src/lib/logger.ts
@@ -75,28 +75,32 @@ export const getLogger = ({
     corrId: false,
     align: true,
     stack: true,
-  };
-  
+  }
+
   const consoleFormattingOptions = {
     ...defaultFormattingOptions,
     ...formattingOptions,
-  };
+  }
 
   if (!loggers[service]) {
     const winstonConsoleFormat = format.combine(
-      consoleFormattingOptions.colorize ? format.colorize({all: true}) : format.uncolorize(),
+      consoleFormattingOptions.colorize
+        ? format.colorize({ all: true })
+        : format.uncolorize(),
       consoleFormattingOptions.timestamp ? format.timestamp() : format.simple(),
       consoleFormattingOptions.align ? format.align() : format.simple(),
       format.printf((info) => {
-        let output = `[${info.timestamp}]`;
+        let output = `[${info.timestamp}]`
         if (consoleFormattingOptions.corrId) {
-          output += ` ${getCorrId()}`;
+          output += ` ${getCorrId()}`
         }
-        output += ` ${info.level}: ${info.message}`;
-        return output;
+        output += ` ${info.level}: ${info.message}`
+        return output
       }),
-      consoleFormattingOptions.stack ? format.errors({ stack: true }) : format.simple()
-    );
+      consoleFormattingOptions.stack
+        ? format.errors({ stack: true })
+        : format.simple()
+    )
 
     const transports: Transport[] =
       process.env.ENVIRONMENT === 'gcp'

--- a/packages/logging/src/lib/logger.ts
+++ b/packages/logging/src/lib/logger.ts
@@ -15,6 +15,7 @@ import {
   format,
 } from 'winston'
 import type * as Transport from 'winston-transport'
+import { getCorrId } from './correlationid'
 
 let loggers: Record<string, Logger> = {}
 
@@ -45,6 +46,7 @@ export type LogOptions = {
     colorize?: boolean
     timestamp?: boolean
     align?: boolean
+    corrId?: boolean
     stack?: boolean
   }
 }
@@ -63,6 +65,7 @@ export const getLogger = ({
   formattingOptions = {
     colorize: true,
     timestamp: true,
+    corrId: false,
     align: true,
     stack: true,
   },
@@ -72,9 +75,14 @@ export const getLogger = ({
       formattingOptions.colorize ? format.colorize() : format.uncolorize(),
       formattingOptions.timestamp ? format.timestamp() : format.simple(),
       formattingOptions.align ? format.align() : format.simple(),
-      format.printf(
-        (info) => `[${info.timestamp}] ${info.level}: ${info.message}`
-      ),
+      format.printf((info) => {
+        let output = `[${info.timestamp}]`;
+        if (formattingOptions.corrId) {
+          output += ` ${getCorrId()}`;
+        }
+        output += ` ${info.level}: ${info.message}`;
+        return output;
+      }),
       formattingOptions.stack ? format.errors({ stack: true }) : format.simple()
     );
 

--- a/packages/logging/src/lib/logger.ts
+++ b/packages/logging/src/lib/logger.ts
@@ -5,7 +5,6 @@ import type {
   RequestHandler,
   Response,
 } from 'express'
-import responseTime from 'response-time'
 import type { Server, Socket } from 'socket.io'
 import wildcard from 'socketio-wildcard'
 import {
@@ -70,20 +69,33 @@ export const getLogger = ({
     stack: true,
   },
 }: LogOptions): LoggerResult => {
+  const defaultFormattingOptions = {
+    colorize: true,
+    timestamp: true,
+    corrId: false,
+    align: true,
+    stack: true,
+  };
+  
+  const consoleFormattingOptions = {
+    ...defaultFormattingOptions,
+    ...formattingOptions,
+  };
+
   if (!loggers[service]) {
     const winstonConsoleFormat = format.combine(
-      formattingOptions.colorize ? format.colorize() : format.uncolorize(),
-      formattingOptions.timestamp ? format.timestamp() : format.simple(),
-      formattingOptions.align ? format.align() : format.simple(),
+      consoleFormattingOptions.colorize ? format.colorize({all: true}) : format.uncolorize(),
+      consoleFormattingOptions.timestamp ? format.timestamp() : format.simple(),
+      consoleFormattingOptions.align ? format.align() : format.simple(),
       format.printf((info) => {
         let output = `[${info.timestamp}]`;
-        if (formattingOptions.corrId) {
+        if (consoleFormattingOptions.corrId) {
           output += ` ${getCorrId()}`;
         }
         output += ` ${info.level}: ${info.message}`;
         return output;
       }),
-      formattingOptions.stack ? format.errors({ stack: true }) : format.simple()
+      consoleFormattingOptions.stack ? format.errors({ stack: true }) : format.simple()
     );
 
     const transports: Transport[] =


### PR DESCRIPTION
Allow format of Winston Console transport to be configured when calling `getLogger`