### PR TITLE
refactor: 💡 move env variables to function params and more

### DIFF
--- a/.changeset/chilly-mayflies-beg.md
+++ b/.changeset/chilly-mayflies-beg.md
@@ -1,0 +1,5 @@
+---
+"@sebspark/logging": major
+---
+
+modify the library to pass configuration settings as function parameters instead of relying on environment variables

--- a/packages/logging/src/lib/logger.ts
+++ b/packages/logging/src/lib/logger.ts
@@ -1,4 +1,4 @@
-import { LoggingWinston } from '@google-cloud/logging-winston'
+import { LoggingWinston, Options } from '@google-cloud/logging-winston'
 import type {
   ErrorRequestHandler,
   Request,
@@ -93,7 +93,7 @@ export const getLogger = ({
           const corrId = getCorrId()
           if (corrId) {
             output += ` [${corrId}]`
-          }          
+          }
         }
         output += ` ${info.level}: ${info.message}`
         return output
@@ -103,7 +103,7 @@ export const getLogger = ({
         : format.simple()
     )
 
-    const loggingWinstonSettings: any = {
+    const loggingWinstonSettings: Options = {
       level,
       serviceContext: {
         service,

--- a/packages/logging/src/lib/logger.ts
+++ b/packages/logging/src/lib/logger.ts
@@ -1,4 +1,4 @@
-import { LoggingWinston, Options } from '@google-cloud/logging-winston'
+import { LoggingWinston, type Options } from '@google-cloud/logging-winston'
 import type {
   ErrorRequestHandler,
   Request,

--- a/packages/logging/src/lib/logger.ts
+++ b/packages/logging/src/lib/logger.ts
@@ -49,7 +49,6 @@ export type LogOptions = {
     align?: boolean
     corrId?: boolean
     stack?: boolean
-    logStatusCodes?: boolean
   }
 }
 export type LoggerResult = {
@@ -145,16 +144,16 @@ export const getLogger = ({
 }
 
 const makeRequestMiddleware =
-  (logger: Logger): RequestHandler =>
+  (logger: Logger, logFunc = logHttp): RequestHandler =>
   async (req, res, next) => {
-    logHttp(logger, req, res)
+    logFunc(logger, req, res)
     next()
   }
 
 const makeRequestErrorMiddleware =
-  (logger: Logger): ErrorRequestHandler =>
+  (logger: Logger, logFunc = logHttpError): ErrorRequestHandler =>
   (error, req, res, next) => {
-    logHttpError(logger, req, res, error)
+    logFunc(logger, req, res, error)
     next(error)
   }
 

--- a/packages/logging/src/lib/logger.ts
+++ b/packages/logging/src/lib/logger.ts
@@ -91,7 +91,10 @@ export const getLogger = ({
       format.printf((info) => {
         let output = `[${info.timestamp}]`
         if (consoleFormattingOptions.corrId) {
-          output += ` ${getCorrId()}`
+          const corrId = getCorrId()
+          if (corrId) {
+            output += ` [${corrId}]`
+          }          
         }
         output += ` ${info.level}: ${info.message}`
         return output


### PR DESCRIPTION
Switch env variables to function params to avoid issues when maintaining the env for both projects